### PR TITLE
Autoinstall

### DIFF
--- a/Install.md
+++ b/Install.md
@@ -133,6 +133,8 @@ This guide helps you build and install Snort.
     sudo sh -c "echo \"huge /mnt/huge hugetlbfs defaults 0 0\" >> /etc/fstab"
     sudo mount -t hugetlbfs nodev /mnt/huge
     ```
+    Further troubleshooting:
+    ```sudo sysctl vm.nr_hugepages=$hp_count```
     
 4. Run openNetVM manager. To install openNetVM, refer to this [guide][onvm-install].
     ```sh

--- a/Install.md
+++ b/Install.md
@@ -93,7 +93,8 @@ This guide helps you build and install Snort.
     ./configure --enable-sourcefire
     ```
 
-3. Create Patch of Makefille      
+3. Create Patch of Makefille 
+    This part is critical for the next steps. The defaults are blank. Please type in the answers manually.
    ```sh
    cd ../
    ./patching-Makefile.sh
@@ -121,19 +122,36 @@ This guide helps you build and install Snort.
     sudo cp -r snort-2.9.8.3/simple-etc /etc/snort
     sudo mkdir /usr/local/lib/snort_dynamicrules
     ```
+2. Add snort to path (change /opt/snort if the install path is different)
+    ```
+    export PATH=$PATH:/opt/snort/bin"
+    ```
+3. Set up huge pages
+    ```export ONVM_NUM_HUGEPAGES=1024
+    hp_size=$(cat /proc/meminfo | grep Hugepagesize | awk '{print $2}')
+    hp_count="${ONVM_NUM_HUGEPAGES:-1024}"
+    sudo mkdir -p /mnt/huge
+    sudo sh -c "echo \"huge /mnt/huge hugetlbfs defaults 0 0\" >> /etc/fstab"
+    sudo mount -t hugetlbfs nodev /mnt/huge
+    ```
     
-2. Run openNetVM manager. To install openNetVM, refer to this [guide][onvm-install].
+4. Run openNetVM manager. To install openNetVM, refer to this [guide][onvm-install].
     ```sh
     cd openNetVM-dev/onvm
     ./go.sh 0,1,2,3,4 3 -v 0x7f000000000
     ```
-3. Run Snort.
+5. Run Snort.
     ```sh
     sudo snort -A console -Q -c /etc/snort/snort.conf -i dpdk0:dpdk1 -N --alert-before-pass --daq-var netvm_args="-l 5 -n 3 --proc-type=secondary -- -r 1 -- -d 4"
     ```
+    If the above does not work then try:
+    ```
+    which snort
+    sudo `which snort` -A console -Q -c /etc/snort/snort.conf -i dpdk0:dpdk1 -N --alert-before-pass --daq-var netvm_args="-l 5 -n 3 --proc-type=secondary -- -r 1 -- -d 4"
+    ```
     ![snort init][snort-init]
     
-3. Run Bridge.
+6. Run Bridge.
     ```sh
     cd openNetVM-dev/examples/bridge/
     ./go.sh 6 4

--- a/Install.md
+++ b/Install.md
@@ -93,8 +93,7 @@ This guide helps you build and install Snort.
     ./configure --enable-sourcefire
     ```
 
-3. Create Patch of Makefille 
-    This part is critical for the next steps. The defaults are blank. Please type in the answers manually.
+3. Create Patch of Makefille. This part is critical for the next steps. The defaults are blank. Please type in the answers manually.
    ```sh
    cd ../
    ./patching-Makefile.sh

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,41 @@
+#! /bin/bash
+
+#                        openNetVM
+#                https://sdnfv.github.io
+#
+# OpenNetVM is distributed under the following BSD LICENSE:
+#
+# Copyright(c)
+#       2015-2016 George Washington University
+#       2015-2016 University of California Riverside
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in
+#   the documentation and/or other materials provided with the
+#   distribution.
+# * The name of the author may not be used to endorse or promote
+#   products derived from this software without specific prior
+#   written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 ls | grep setenv.sh
 ANS=`echo $?`
 if [ $ANS == 1 ]

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,55 @@
+ls | grep setenv.sh
+ANS=`echo $?`
+if [ $ANS == 1 ]
+then
+	echo please run this script in situ
+	exit
+fi
+
+./setenv.sh
+
+# Base directory
+BASE_DIR=$(pwd)
+
+# update
+sudo apt-get update
+
+make -j7 T=$RTE_TARGET O=$RTE_TARGET
+sudo make install T=x86_64-native-linuxapp-gcc
+
+cd onvm && make
+
+# Compile DAQ
+sudo apt-get install -y libpcap-dev libpcre3-dev libdumbnet-dev zlib1g-dev liblzma-dev libssl-dev autoconf
+
+cd $BASE_DIR/daq*
+
+make clean
+aclocal
+autoconf
+autoheader
+automake -a
+
+./configure --with-dpdk-includes=$RTE_SDK/$RTE_TARGET/include --with-dpdk-libraries=$RTE_SDK/$RTE_TARGET/lib --with-netvm-includes=$ONVM_HOME/onvm --with-netvm-libraries=$ONVM_HOME/onvm
+
+make -j7
+sudo make install
+
+# Compile snort
+cd $BASE_DIR/snort*
+./configure --enable-sourcefire
+
+cd snort*/src
+make clean
+make -j7
+sudo make install
+
+sudo ldconfig
+
+sudo cp -r snort*/simple-etc /etc/snort
+sudo mkdir /usr/local/lib/snort_dynamicrules
+
+cd $ONVM_HOME
+scripts/install.sh
+
+cd $BASE_DIR

--- a/patching-Makefile.sh
+++ b/patching-Makefile.sh
@@ -10,10 +10,24 @@ if [ ! -e $_MAIN_FILE_TO_PATCH ];then
 fi
 # Insert Directory of Cloned Repo
 read -p "onvm-snort cloned at [$(realpath `pwd`/..)] (example: /home/user): " _DIR || exit 10
+if [ -z "_DIR" ]
+then
+	_DIR=$HOME
+fi
 _DIR=${_DIR:-$(realpath `pwd`/..)}/onvm-snort/
+
 read -p "Snort will install to [/usr/local/] (example: /opt/snort): " _SNORT_INSTALL || exit 10
+if [ -z "$_SNORT_INSTALL" ]
+then
+	_SNORT_INSTALL=/opt/snort
+fi
 _SNORT_INSTALL=${_SNORT_INSTALL:-/usr/local/}
+
 read -p "DAQ Install PATH [Using System as Default] (example: /opt/daq): " _DAQ_INSTALL || exit 10
+if [ -z "$_DAQ_INSTALL" ]
+then
+	_DAQ_INSTALL=/opt/daq
+fi
 _DAQ_INSTALL=${_DAQ_INSTALL:- }
 
 # Create patched file

--- a/patching-Makefile.sh
+++ b/patching-Makefile.sh
@@ -1,4 +1,40 @@
-#!/bin/bash
+#! /bin/bash
+
+#                        openNetVM
+#                https://sdnfv.github.io
+#
+# OpenNetVM is distributed under the following BSD LICENSE:
+#
+# Copyright(c)
+#       2015-2016 George Washington University
+#       2015-2016 University of California Riverside
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in
+#   the documentation and/or other materials provided with the
+#   distribution.
+# * The name of the author may not be used to endorse or promote
+#   products derived from this software without specific prior
+#   written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 _PATCH_FILE_NAME=Makefile.patched
 _MAIN_FILE_TO_PATCH=Makefile.dpdk

--- a/setenv.sh
+++ b/setenv.sh
@@ -1,3 +1,41 @@
+#! /bin/bash
+
+#                        openNetVM
+#                https://sdnfv.github.io
+#
+# OpenNetVM is distributed under the following BSD LICENSE:
+#
+# Copyright(c)
+#       2015-2016 George Washington University
+#       2015-2016 University of California Riverside
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in
+#   the documentation and/or other materials provided with the
+#   distribution.
+# * The name of the author may not be used to endorse or promote
+#   products derived from this software without specific prior
+#   written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 ls | grep setenv.sh
 ANS=`echo $?`
 if [ $ANS == 1 ]

--- a/setenv.sh
+++ b/setenv.sh
@@ -1,0 +1,86 @@
+ls | grep setenv.sh
+ANS=`echo $?`
+if [ $ANS == 1 ]
+then
+	echo please run this script in situ
+	exit
+fi
+
+sudo apt-get install realpath
+
+# Base directory
+BASE_DIR=$(pwd)
+
+grep RTE_TARGET ~/.bashrc
+ANS=`echo $?`
+if [ $ANS == 1 ]
+then
+	echo export RTE_TARGET=x86_64-native-linuxapp-gcc >> ~/.bashrc
+fi
+
+grep DPDK_TARGET ~/.bashrc
+ANS=`echo $?`
+if [ $ANS == 1 ]
+then
+	echo export DPDK_TARGET=x86_64-native-linuxapp-gcc >> ~/.bashrc
+fi
+
+cd $BASE_DIR/dpdk*
+grep RTE_SDK ~/.bashrc
+ANS=`echo $?`
+if [ $ANS == 1 ]
+then
+	echo export RTE_SDK=$(pwd) >> ~/.bashrc
+fi
+
+cd $BASE_DIR/openNetVM*
+grep ONVM_HOME ~/.bashrc
+ANS=`echo $?`
+if [ $ANS == 1 ]
+then
+	echo export ONVM_HOME=$(pwd) >> ~/.bashrc
+fi
+
+cd $BASE_DIR
+ls | grep Makefile.patched
+ANS=`echo $?`
+if [ $ANS == 0 ]
+then
+	read -p "Do you want to create the snort Makefile again? (y/N): " ANS
+else
+	ANS='y'
+fi
+
+if [ "$ANS" == "y" ]
+then
+	./patching-Makefile.sh
+	cp ./Makefile.patched $BASE_DIR/snort*/src/
+fi
+
+grep "/opt/snort" ~/.bashrc
+ANS=`echo $?`
+if [ $ANS == 0 ]
+then
+	echo export PATH=$PATH:/opt/snort/bin >> ~/.bashrc
+fi
+
+grep ONVM_NUM_HUGEPAGES ~/.bashrc
+ANS=`echo $?`
+if [ $ANS == 1 ]
+then
+	echo export ONVM_NUM_HUGEPAGES=1024 >> ~/.bashrc
+fi
+
+echo using nics 06:00.0 and 06:00.1
+grep ONVM_NIC_PCI ~/.bashrc
+ANS=`echo $?`
+if [ $ANS == 1 ]
+then
+	echo 'export ONVM_NIC_PCI=" 06:00.0 06:00.1 "' >> ~/.bashrc
+fi
+
+source ~/.bashrc
+
+sudo sh -c "echo 0 > /proc/sys/kernel/randomize_va_space"
+
+cd $BASE_DIR


### PR DESCRIPTION
Added install.sh and setenv.sh to automate snort installation. Also modified patching-Makefile.sh to use default values.

patching-Makefile.sh has been modified to accept default values. This file is now called from inside setenv.sh. setenv.sh sets up all initial enviornment variables assuming defaults. The variables in this file can be changed if defaults are not used. The setenv.sh script is run from inside install.sh. This script essentially, sets up all environment variables, installs all packages and builds all the tools.